### PR TITLE
fix: Don't use hyphens in the exported names

### DIFF
--- a/src/HarvestJobLambda.ts
+++ b/src/HarvestJobLambda.ts
@@ -171,7 +171,7 @@ export class HarvestJobLambda extends Construct {
         const jsonStr = JSON.stringify(document);
         new CfnOutput(this, 'BucketPolicyJson', {
           value: jsonStr,
-          exportName: `${Aws.STACK_ID}-BucketPolicyJson`,
+          exportName: `${Aws.STACK_ID}BucketPolicyJson`,
           description: 'The bucket policy JSON.',
         });
         new AwsCustomResource(this, 'PutBucketPolicy', {


### PR DESCRIPTION
Fixes #